### PR TITLE
feat: add Tavily as alternative search provider in OpenSeeker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,4 +53,5 @@ typing_extensions==4.15.0
 urllib3==2.6.3
 websocket-client==1.9.0
 Wikipedia-API==0.10.2
+tavily-python>=0.5.0
 yarl==1.23.0

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -47,6 +47,7 @@ export JINA_API_KEYS="${JINA_API_KEYS:-YOUR_JINA_API_KEY}"
 # Get your API key from https://serper.dev/
 export SERPER_KEY_ID="${SERPER_KEY_ID:-YOUR_SERPER_API_KEY}"
 
+# If you want to use Tavily for search, you can configure the following parameters. Use Serper by default.
 # ============================================
 # Tavily API Configuration (for search.py)
 # ============================================

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -48,6 +48,14 @@ export JINA_API_KEYS="${JINA_API_KEYS:-YOUR_JINA_API_KEY}"
 export SERPER_KEY_ID="${SERPER_KEY_ID:-YOUR_SERPER_API_KEY}"
 
 # ============================================
+# Tavily API Configuration (for search.py)
+# ============================================
+# Get your API key from https://app.tavily.com/
+export TAVILY_API_KEY="${TAVILY_API_KEY:-YOUR_TAVILY_API_KEY}"
+# Search provider: 'serper' (default) or 'tavily'
+export SEARCH_PROVIDER="${SEARCH_PROVIDER:-serper}"
+
+# ============================================
 # Other Configuration
 # ============================================
 # Visit tool configuration
@@ -69,4 +77,6 @@ echo "SUMMARY_API_URL: $SUMMARY_API_URL"
 echo "SUMMARY_API_KEY: ${SUMMARY_API_KEY:0:20}..."
 echo "JINA_API_KEYS: ${JINA_API_KEYS:0:20}..."
 echo "SERPER_KEY_ID: ${SERPER_KEY_ID:0:20}..."
+echo "TAVILY_API_KEY: ${TAVILY_API_KEY:0:20}..."
+echo "SEARCH_PROVIDER: $SEARCH_PROVIDER"
 echo "============================================"

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -10,9 +10,12 @@ import http.client
 import json
 
 import os
+from tavily import TavilyClient
 
 
 SERPER_KEY=os.environ.get('SERPER_KEY_ID', "YOUR_SERPER_API_KEY")
+SEARCH_PROVIDER=os.environ.get('SEARCH_PROVIDER', 'serper')
+TAVILY_API_KEY=os.environ.get('TAVILY_API_KEY', '')
 
 
 @register_tool("search", allow_overwrite=True)
@@ -113,9 +116,44 @@ class Search(BaseTool):
 
 
     
+    def search_with_tavily(self, query: str):
+        try:
+            tavily_client = TavilyClient(api_key=TAVILY_API_KEY)
+            response = tavily_client.search(query=query, max_results=10)
+        except Exception as e:
+            print(e)
+            return f"Tavily search failed for '{query}'. Please try again later."
+
+        try:
+            results = response.get("results", [])
+            if not results:
+                return f"No results found for '{query}'. Try with a more general query."
+
+            web_snippets = []
+            for idx, result in enumerate(results, start=1):
+                title = result.get("title", "")
+                url = result.get("url", "")
+                content = result.get("content", "")
+                date_published = ""
+                if result.get("published_date"):
+                    date_published = "\nDate published: " + result["published_date"]
+
+                redacted_version = f"{idx}. [{title}]({url}){date_published}\n{content}"
+                web_snippets.append(redacted_version)
+
+            content = f"### A Tavily search for '{query}' found {len(web_snippets)} results:\n\n" + "\n\n".join(web_snippets)
+            return content
+        except Exception:
+            return f"No results found for '{query}'. Try with a more general query."
+
     def search_with_serp(self, query: str):
         result = self.google_search_with_serp(query)
         return result
+
+    def _dispatch_search(self, query: str):
+        if SEARCH_PROVIDER == 'tavily':
+            return self.search_with_tavily(query)
+        return self.search_with_serp(query)
 
     def call(self, params: Union[str, dict], **kwargs) -> str:
         try:
@@ -125,13 +163,13 @@ class Search(BaseTool):
         
         if isinstance(query, str):
             # 单个查询
-            response = self.search_with_serp(query)
+            response = self._dispatch_search(query)
         else:
             # 多个查询
             assert isinstance(query, List)
             responses = []
             for q in query:
-                responses.append(self.search_with_serp(q))
+                responses.append(self._dispatch_search(q))
             response = "\n---\n".join(responses)
             
         return response


### PR DESCRIPTION
## Summary

- Added Tavily as a configurable search backend alongside the existing Serper provider
- Search provider is controlled via `SEARCH_PROVIDER` env var (`serper` default, `tavily` option)
- Tavily results are formatted to match the existing numbered snippet format used by Serper
- Existing Serper code paths remain completely untouched

## Files Changed

- **`src/tools/search.py`** — Added `TavilyClient` import, `SEARCH_PROVIDER` / `TAVILY_API_KEY` env var reads, `search_with_tavily()` method, and `_dispatch_search()` routing helper. Updated `call()` to use dispatcher.
- **`setup_env.sh`** — Added `TAVILY_API_KEY` and `SEARCH_PROVIDER` env var declarations with defaults, plus echo lines for verification.
- **`requirements.txt`** — Added `tavily-python>=0.5.0` dependency.

## Dependency Changes

- Added `tavily-python>=0.5.0` to `requirements.txt`

## Environment Variable Changes

- Added `TAVILY_API_KEY` (required when `SEARCH_PROVIDER=tavily`)
- Added `SEARCH_PROVIDER` (default: `serper`, accepted values: `serper`, `tavily`)

## Notes for Reviewers

- This is an additive/parallel migration — Serper remains the default and is fully functional
- To use Tavily, set `export SEARCH_PROVIDER=tavily` and provide a valid `TAVILY_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is functionally correct and additive. All three reported files were modified. Serper remains the default, existing logic is fully preserved, and the dispatch pattern is clean. The Tavily SDK is used correctly (TavilyClient, .search(), correct response fields). Three minor issues exist: (1) unpinned version specifier in requirements.txt, (2) unconditional top-level import of TavilyClient, and (3) a local variable name shadow in search_with_tavily. None are blocking.
