### PR TITLE
Add OpenAI tool-call v3 runner with code_exec

### DIFF
--- a/eval/generate_answer_v3.py
+++ b/eval/generate_answer_v3.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Any, Dict, List, Set, Tuple
+
+
+BOX_FORMAT_INSTRUCTION = (
+    "\n\nYou should follow the format instruction in the request strictly "
+    "and wrap the final answer in \\\\boxed{}."
+)
+
+
+def read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    data: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            data.append(json.loads(line))
+    return data
+
+
+def append_box_instruction(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    boxed_data: List[Dict[str, Any]] = []
+    for item in data:
+        boxed_item = dict(item)
+        query = boxed_item.get("query", "")
+        if isinstance(query, str) and BOX_FORMAT_INSTRUCTION not in query:
+            boxed_item["query"] = query + BOX_FORMAT_INSTRUCTION
+        boxed_data.append(boxed_item)
+    return boxed_data
+
+
+
+
+def get_queries_without_answer(
+    save_path: Path, all_queries: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """
+    Check which queries in all_queries don't have valid answers in save_path.
+    A query is considered to have an answer if:
+    - It exists in save_path AND
+    - It has a 'final_response' field that is non-empty (after stripping)
+
+    Returns:
+        List of query dicts that don't have valid answers
+    """
+    if not save_path.exists():
+        return all_queries
+
+    query_to_has_answer: Dict[str, bool] = {}
+    with save_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                q = obj.get("query")
+                if isinstance(q, str) and q:
+                    final_response = obj.get("final_response", "")
+                    has_answer = bool(final_response and str(final_response).strip())
+                    query_to_has_answer[q] = has_answer
+            except Exception:
+                continue
+
+    missing = []
+    for item in all_queries:
+        q = item.get("query", "")
+        if isinstance(q, str) and q:
+            if q not in query_to_has_answer or not query_to_has_answer[q]:
+                missing.append(item)
+
+    return missing
+
+
+def _safe_float(x: Any):
+    try:
+        if x is None:
+            return None
+        return float(x)
+    except Exception:
+        return None
+
+
+def compute_metrics(result_jsonl: Path) -> Dict[str, Any]:
+    """
+    Compute aggregate metrics from a result jsonl file.
+    """
+    n = 0
+    tool_calls: List[float] = []
+    context_chars: List[float] = []
+    elapsed_seconds: List[float] = []
+
+    if not result_jsonl.exists():
+        return {"count": 0}
+
+    with result_jsonl.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except Exception:
+                continue
+            n += 1
+            tc = _safe_float(obj.get("tool_calls"))
+            cc = _safe_float(obj.get("context_chars"))
+            es = _safe_float(obj.get("elapsed_seconds"))
+            if tc is not None:
+                tool_calls.append(tc)
+            if cc is not None:
+                context_chars.append(cc)
+            if es is not None:
+                elapsed_seconds.append(es)
+
+    def _mean(xs: List[float]):
+        return (sum(xs) / len(xs)) if xs else None
+
+    def _min(xs: List[float]):
+        return min(xs) if xs else None
+
+    def _max(xs: List[float]):
+        return max(xs) if xs else None
+
+    return {
+        "count": n,
+        "tool_calls": {"mean": _mean(tool_calls), "min": _min(tool_calls), "max": _max(tool_calls)},
+        "context_chars": {"mean": _mean(context_chars), "min": _min(context_chars), "max": _max(context_chars)},
+        "elapsed_seconds": {"mean": _mean(elapsed_seconds), "min": _min(elapsed_seconds), "max": _max(elapsed_seconds)},
+    }
+
+
+class Tee:
+    """
+    Duplicate writes to multiple file-like objects (e.g., console + log file).
+    """
+
+    def __init__(self, *streams):
+        self.streams = streams
+
+    def write(self, s: str) -> int:
+        n = 0
+        for st in self.streams:
+            try:
+                n = st.write(s)
+            except Exception:
+                pass
+        return n
+
+    def flush(self) -> None:
+        for st in self.streams:
+            try:
+                st.flush()
+            except Exception:
+                pass
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max_tokens", type=int, default=32768)
+    parser.add_argument("--tool_count_max", type=int, default=200)
+    parser.add_argument("--max_worker", type=int, default=60)
+    parser.add_argument("--pool_no_progress_timeout", type=int, default=18000)
+    parser.add_argument("--print_stream", action="store_true", default=True)
+    parser.add_argument("--sequential", action="store_true")
+    parser.add_argument(
+        "--use_box",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Append a \\\\boxed{} final-answer format instruction to each query. Enabled by default; use --no-use_box to disable.",
+    )
+    parser.add_argument(
+        "--pool_restart_rounds",
+        type=int,
+        default=0,
+        help="When no progress for pool_no_progress_timeout, restart the async pool and rerun remaining tasks for this many extra rounds.",
+    )
+    parser.add_argument(
+        "--max_retry_rounds",
+        type=int,
+        default=1,
+        help="Maximum number of retry rounds to process queries without answers. After each round, check which queries still don't have answers and retry them. Set to 0 to disable auto-retry.",
+    )
+    parser.add_argument(
+        "--filter_huggingface",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Filter out search results whose link contains 'huggingface'. Enabled by default; use --no-filter_huggingface to disable.",
+    )
+
+    _eval_dir = Path(__file__).parent.absolute()
+
+    parser.add_argument(
+        "--dataset_path",
+        type=Path,
+        default="",
+        help="Path to the dataset JSONL file",
+    )
+    parser.add_argument(
+        "--out_dir",
+        type=Path,
+        default="",
+        help="Output directory for results",
+    )
+    parser.add_argument("--limit", type=int, default=-1, help="Run at most N questions.")
+    parser.add_argument(
+        "--run-log-path",
+        type=Path,
+        default=None,
+        help="Save full run logs (stdout/stderr) to this file. Default: auto under out_dir.",
+    )
+    parser.add_argument(
+        "--no-run-log",
+        action="store_true",
+        help="Disable saving full run logs (stdout/stderr).",
+    )
+    args = parser.parse_args()
+    run_start_ts = time.time()
+
+    import sys as _sys
+
+    utils_dir = os.path.join(os.path.dirname(__file__), "..", "src")
+    if str(utils_dir) not in _sys.path:
+        _sys.path.insert(0, str(utils_dir))
+    from llm_tool_openseeker_v3 import solve_query_with_tools
+
+    test_data = read_jsonl(args.dataset_path)
+    if args.use_box:
+        test_data = append_box_instruction(test_data)
+    if args.limit != -1:
+        test_data = test_data[: args.limit]
+    print(f">> Loaded {len(test_data)} questions from {args.dataset_path}")
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    save_path = args.out_dir / f"result_tool{args.tool_count_max}.jsonl"
+    log_path = args.out_dir / f"result_tool{args.tool_count_max}.log.txt"
+    run_log_path = args.run_log_path or (
+        args.out_dir / f"result_tool{args.tool_count_max}.run.log"
+    )
+    metric_path = args.out_dir / f"result_tool{args.tool_count_max}_metrics.json"
+
+    run_log_f = None
+    orig_stdout, orig_stderr = sys.stdout, sys.stderr
+    if not args.no_run_log:
+        try:
+            run_log_f = run_log_path.open("a", encoding="utf-8")
+            sys.stdout = Tee(orig_stdout, run_log_f)
+            sys.stderr = Tee(orig_stderr, run_log_f)
+            print(f">> Run log: {run_log_path}")
+        except Exception as e:
+            sys.stdout, sys.stderr = orig_stdout, orig_stderr
+            print(f">> Failed to enable run log at {run_log_path}: {e}")
+
+    print(">> Config:")
+    print(
+        json.dumps(
+            {
+                "max_tokens": args.max_tokens,
+                "tool_count_max": args.tool_count_max,
+                "max_worker": args.max_worker,
+                "base_url": os.getenv("OPENSEEKER_BASE_URL", "YOUR_OPENSEEKER_BASE_URL"),
+                "model": os.getenv("OPENSEEKER_MODEL", "YOUR_MODEL_NAME"),
+                "pool_no_progress_timeout": args.pool_no_progress_timeout,
+                "filter_huggingface": args.filter_huggingface,
+                "dataset_path": str(args.dataset_path),
+                "use_box": args.use_box,
+                "save_path": str(save_path),
+                "error_log_path": str(log_path),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+    before = len(test_data)
+    test_data = get_queries_without_answer(save_path, test_data)
+    skipped = before - len(test_data)
+    if skipped:
+        print(f">> Dedup (valid answers only): {before} -> {len(test_data)} (skipped={skipped})")
+
+    lock = asyncio.Lock()
+
+    async def process_one(data: Dict[str, Any]) -> bool:
+        q = data.get("query", "")
+        t0 = time.time()
+        print(f">> START query={q[:120]!r}")
+        try:
+            res = await asyncio.to_thread(
+                solve_query_with_tools,
+                q,
+                max_tokens=args.max_tokens,
+                tool_count_max=args.tool_count_max,
+                print_stream=args.print_stream,
+                filter_huggingface=args.filter_huggingface,
+                return_full_traj=True,
+            )
+            out = dict(data)
+            out["final_response"] = res.get("answer", "")
+            out["tool_calls"] = res.get("tool_calls", None)
+            out["elapsed_seconds"] = res.get("elapsed_seconds", None)
+            out["context_chars"] = res.get("context_chars", None)
+            out["context_est_tokens"] = res.get("context_est_tokens", None)
+            out["finish_reason"] = res.get("finish_reason", None)
+            if res.get("error") is not None:
+                out["error"] = res.get("error")
+            out["full_traj"] = res.get("full_traj", "")
+            out["trace"] = res.get("trace", "")
+            out["wall_seconds"] = time.time() - t0
+
+            async with lock:
+                with save_path.open("a", encoding="utf-8") as f:
+                    f.write(json.dumps(out, ensure_ascii=False) + "\n")
+                    f.flush()
+            print(
+                f">> DONE  query={q[:120]!r} "
+                f"wall={out['wall_seconds']:.2f}s tool_calls={out.get('tool_calls')} "
+                f"ctx_chars={out.get('context_chars')}"
+            )
+            return True
+        except Exception as e:
+            err = traceback.format_exc()
+            print(f"\033[91m>> FAILED query={q[:120]!r}\033[0m")
+            print(f"\033[91m>> Error type: {type(e).__name__}\033[0m")
+            print(f"\033[91m>> Error message: {str(e)}\033[0m")
+            print(f"\033[91m>> Full traceback:\n{err}\033[0m")
+            async with lock:
+                with log_path.open("a", encoding="utf-8") as f:
+                    f.write(f">> Error in processing query: {q}\n")
+                    f.write(f">> Error type: {type(e).__name__}\n")
+                    f.write(f">> Error message: {str(e)}\n")
+                    f.write(err + "\n")
+            print(f"\033[91m>> Query NOT saved to results file (will be retried later)\033[0m")
+            return False
+
+    def finalize() -> None:
+        metrics = compute_metrics(save_path)
+        metrics["run_total_seconds"] = time.time() - run_start_ts
+        metrics["run_started_at_unix"] = run_start_ts
+        metrics["run_finished_at_unix"] = time.time()
+        try:
+            metric_path.write_text(json.dumps(metrics, ensure_ascii=False, indent=2), encoding="utf-8")
+        except Exception as e:
+            print(f">> Failed to write metrics to {metric_path}: {e}")
+        print(f">> Metrics saved to {metric_path}")
+        tc_mean = (metrics.get("tool_calls") or {}).get("mean")
+        cc_mean = (metrics.get("context_chars") or {}).get("mean")
+        print(f">> Avg tool_calls: {tc_mean}")
+        print(f">> Avg context_chars: {cc_mean}")
+        print(f">> Total run wall time (seconds): {metrics.get('run_total_seconds')}")
+
+    async def run_processing_round(data_to_process: List[Dict[str, Any]]) -> Tuple[Set[str], Set[str]]:
+        """
+        Run one round of processing on the given data.
+        Returns: (completed_ok_set, failed_final_set)
+        """
+        if args.sequential:
+            completed_ok: Set[str] = set()
+            failed_final: Set[str] = set()
+            for d in data_to_process:
+                q = d.get("query", "")
+                ok = await process_one(d)
+                if isinstance(q, str) and q:
+                    if ok:
+                        completed_ok.add(q)
+                    else:
+                        failed_final.add(q)
+            return completed_ok, failed_final
+
+        print("\n" + "=" * 100 + "\n>> Start to process the test data...")
+        remaining = list(data_to_process)
+        rounds_total = max(0, int(args.pool_restart_rounds)) + 1
+        completed_ok: Set[str] = set()
+        failed_final: Set[str] = set()
+
+        for round_idx in range(rounds_total):
+            if not remaining:
+                break
+            print(f">> Pool round {round_idx + 1}/{rounds_total}: remaining={len(remaining)}")
+
+            semaphore = asyncio.Semaphore(args.max_worker)
+            task2item: Dict[asyncio.Task, Dict[str, Any]] = {}
+
+            async def process_with_semaphore(item: Dict[str, Any]) -> Tuple[str, bool]:
+                async with semaphore:
+                    q = item.get("query", "")
+                    ok = await process_one(item)
+                    return q, ok
+
+            tasks = []
+            for d in remaining:
+                task = asyncio.create_task(process_with_semaphore(d))
+                tasks.append(task)
+                task2item[task] = d
+
+            pending = set(tasks)
+            last_progress = time.time()
+            done_count = 0
+            round_ok: Set[str] = set()
+            round_fail: Set[str] = set()
+
+            while pending:
+                try:
+                    done, pending = await asyncio.wait(pending, timeout=5, return_when=asyncio.FIRST_COMPLETED)
+                    if not done:
+                        if time.time() - last_progress > args.pool_no_progress_timeout:
+                            print(
+                                f"\n>> No progress for {args.pool_no_progress_timeout}s. "
+                                f"Restarting pool; carry over remaining={len(pending)} tasks…"
+                            )
+                            break
+                        continue
+
+                    last_progress = time.time()
+                    for task in done:
+                        item = task2item.get(task, {})
+                        q = item.get("query", "")
+                        try:
+                            q_result, ok = task.result()
+                            if isinstance(q_result, str) and q_result:
+                                q = q_result
+                            if isinstance(q, str) and q:
+                                if ok:
+                                    round_ok.add(q)
+                                else:
+                                    round_fail.add(q)
+                        except Exception as e:
+                            if isinstance(q, str) and q:
+                                round_fail.add(q)
+                    done_count += len(done)
+                    if done_count % 10 == 0:
+                        print(f">> Progress (round {round_idx + 1}): {done_count}/{len(tasks)}")
+
+                except Exception as e:
+                    print(f">> Error in round processing: {e}")
+                    break
+
+            to_retry = []
+            for task in pending:
+                item = task2item.get(task)
+                if item is not None:
+                    to_retry.append(item)
+                task.cancel()
+
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+            completed_ok |= round_ok
+            failed_final |= round_fail
+
+            remaining = to_retry
+
+        if remaining:
+            print(f">> WARNING: still remaining after {rounds_total} rounds: {len(remaining)} (likely stuck).")
+            async with lock:
+                with log_path.open("a", encoding="utf-8") as f:
+                    f.write(f">> WARNING: remaining tasks after rounds_total={rounds_total}: {len(remaining)}\n")
+                    for d in remaining:
+                        f.write(f"  - {d.get('query','')}\n")
+
+        return completed_ok, failed_final
+
+    total_all = len(test_data)
+    all_completed_ok: Set[str] = set()
+    all_failed_final: Set[str] = set()
+    current_data = list(test_data)
+    retry_round = 0
+
+    while current_data and (args.max_retry_rounds == 0 or retry_round < args.max_retry_rounds):
+        if retry_round == 0:
+            print(f"\n>> Initial processing round: {len(current_data)} queries")
+        else:
+            print(f"\n>> Retry round {retry_round}: processing {len(current_data)} queries without answers")
+
+        round_ok, round_fail = await run_processing_round(current_data)
+        all_completed_ok |= round_ok
+        all_failed_final |= round_fail
+
+        # Check which queries still don't have answers
+        if args.max_retry_rounds > 0:
+            current_data = get_queries_without_answer(save_path, test_data)
+            if current_data:
+                retry_round += 1
+                print(f">> Found {len(current_data)} queries without answers, will retry in next round")
+                if retry_round >= args.max_retry_rounds:
+                    print(f">> Reached max_retry_rounds={args.max_retry_rounds}, stopping retry")
+                    break
+            else:
+                print(f">> All queries have answers! Stopping retry loop.")
+                break
+        else:
+            # If max_retry_rounds is 0, disable auto-retry
+            break
+
+    if current_data and args.max_retry_rounds > 0:
+        print(f">> WARNING: After {retry_round} retry rounds, {len(current_data)} queries still don't have answers.")
+        async with lock:
+            with log_path.open("a", encoding="utf-8") as f:
+                f.write(f">> WARNING: After {retry_round} retry rounds, {len(current_data)} queries still don't have answers:\n")
+                for d in current_data:
+                    f.write(f"  - {d.get('query','')}\n")
+
+    print(f">> Done. Saved to {save_path}")
+    print(f">> Summary: total={total_all} ok_written={len(all_completed_ok)} failed_not_written={len(all_failed_final)}")
+    if args.max_retry_rounds > 0:
+        print(f">> Retry rounds executed: {retry_round}")
+    finalize()
+
+    # Restore stdout/stderr and close run log file
+    try:
+        sys.stdout, sys.stderr = orig_stdout, orig_stderr
+    except Exception:
+        pass
+    try:
+        if run_log_f is not None:
+            run_log_f.flush()
+            run_log_f.close()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/llm_tool_openseeker_v3.py
+++ b/src/llm_tool_openseeker_v3.py
@@ -1,0 +1,469 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+from openai import OpenAI
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _THIS_DIR)
+
+from tools.code_exec import CODE_EXEC_TOOL_SCHEMA, code_exec
+from tools.search import Search
+from tools.visit import Visit
+
+
+def print_colored(text: str, color: int) -> None:
+    print(f"\033[{color}m{text}\033[0m", end="", flush=True)
+
+
+def _tool_color(tool_name: str) -> int:
+    if tool_name == "search":
+        return 34
+    if tool_name in ("visit", "visit_summary"):
+        return 33
+    if tool_name == "code_exec":
+        return 36
+    return 35
+
+
+def _truncate_text(s: Any, max_chars: int) -> str:
+    ss = "" if s is None else str(s)
+    if max_chars <= 0 or len(ss) <= max_chars:
+        return ss
+    head = max(0, int(max_chars * 0.7))
+    tail = max_chars - head
+    return f"{ss[:head]}...<truncated {len(ss)-max_chars} chars>...{ss[-tail:] if tail > 0 else ''}"
+
+
+def _print_tool_call(tool_name: str, tool_args: Any, tool_response: str) -> None:
+    max_chars = 800
+    c = _tool_color(tool_name)
+    try:
+        args_str = json.dumps(tool_args, ensure_ascii=False, sort_keys=True)
+    except Exception:
+        args_str = str(tool_args)
+    print_colored(f"\n[{tool_name}] args={_truncate_text(args_str, max_chars)}\n", c)
+    print_colored(f"[{tool_name}] response={_truncate_text(tool_response, max_chars)}\n", c)
+
+
+developer_prompt = (
+    "You are a tool-augmented QA agent. Cleverly leverage appropriate tools to answer the user's question. "
+    "When the answer is ready, provide the final answer directly and do not call more tools."
+)
+
+search_description = (
+    "Performs batched web searches: supply an array 'query'; the tool retrieves the top 10 results for each query in one call."
+)
+
+visit_description = "Parse webpage(s) and return the summary of the content according to the goal."
+
+tools_visit: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "description": search_description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Array of query strings. Include multiple complementary search queries in a single call.",
+                    }
+                },
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "visit",
+            "description": visit_description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": ["string", "array"],
+                        "items": {"type": "string"},
+                        "minItems": 1,
+                        "description": "The URL(s) of the webpage(s) to visit. Can be a single URL or an array of URLs.",
+                    },
+                    "goal": {"type": "string", "description": "The goal of the visit for webpage(s)."},
+                },
+                "required": ["url", "goal"],
+            },
+        },
+    },
+]
+
+tools_all: List[Dict[str, Any]] = tools_visit + [CODE_EXEC_TOOL_SCHEMA]
+
+
+def _normalize_base_url(base_or_full: str) -> str:
+    s = (base_or_full or "").strip()
+    if not s:
+        raise ValueError("Empty base_url")
+    if s.endswith("/chat/completions"):
+        s = s[: -len("/chat/completions")]
+    if s.endswith("/completions"):
+        s = s[: -len("/completions")]
+    if s.endswith("/v1"):
+        return s
+    if s.endswith("/v1/"):
+        return s[:-1]
+    return s.rstrip("/") + "/v1"
+
+
+def _parse_tool_arguments(raw: Any) -> Dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        try:
+            obj = json.loads(raw or "{}")
+            return obj if isinstance(obj, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _message_to_dict(message: Any) -> Dict[str, Any]:
+    if hasattr(message, "model_dump"):
+        dumped = message.model_dump(exclude_none=True)
+    elif isinstance(message, dict):
+        dumped = {k: v for k, v in message.items() if v is not None}
+    else:
+        dumped = {
+            "role": getattr(message, "role", "assistant"),
+            "content": getattr(message, "content", None),
+        }
+        tool_calls = getattr(message, "tool_calls", None)
+        if tool_calls:
+            dumped["tool_calls"] = [
+                tc.model_dump(exclude_none=True) if hasattr(tc, "model_dump") else tc for tc in tool_calls
+            ]
+    dumped.setdefault("role", "assistant")
+    if "content" not in dumped:
+        dumped["content"] = ""
+    return dumped
+
+
+def _extract_tool_calls(message: Dict[str, Any]) -> List[Dict[str, Any]]:
+    tool_calls = message.get("tool_calls") or []
+    out: List[Dict[str, Any]] = []
+    for idx, tc in enumerate(tool_calls):
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function") or {}
+        if not isinstance(fn, dict):
+            continue
+        name = (fn.get("name") or "").strip()
+        if not name:
+            continue
+        out.append(
+            {
+                "id": tc.get("id") or f"call_{uuid.uuid4().hex}_{idx}",
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": fn.get("arguments") or "{}",
+                },
+            }
+        )
+    return out
+
+
+def _execute_tool(
+    tool_name: str,
+    tool_args: Dict[str, Any],
+    *,
+    filter_huggingface: bool = False,
+) -> str:
+    if tool_name == "search":
+        return Search({"filter_huggingface": filter_huggingface}).call(tool_args)
+    if tool_name in ("visit", "visit_summary"):
+        return Visit().call(tool_args)
+    if tool_name == "code_exec":
+        return code_exec(str(tool_args.get("cmd") or ""))
+    return "Unknown tool or call tool with incorrect format."
+
+
+def _build_client() -> Tuple[OpenAI, str]:
+    base_url = os.getenv("OPENSEEKER_BASE_URL", "YOUR_OPENSEEKER_BASE_URL")
+    if base_url == "YOUR_OPENSEEKER_BASE_URL":
+        raise ValueError("OPENSEEKER_BASE_URL environment variable is required")
+    model_name = os.getenv("OPENSEEKER_MODEL", "YOUR_MODEL_NAME")
+    if model_name == "YOUR_MODEL_NAME":
+        raise ValueError("OPENSEEKER_MODEL environment variable is required")
+    api_key = os.getenv("OPENSEEKER_API_KEY") or os.getenv("OPENAI_API_KEY") or "EMPTY"
+    client = OpenAI(api_key=api_key, base_url=_normalize_base_url(base_url))
+    return client, model_name
+
+
+def _extra_body_from_env() -> Dict[str, Any] | None:
+    raw = os.getenv("OPENSEEKER_REQUEST_EXTRA_BODY_JSON", "").strip()
+    if not raw:
+        return None
+    try:
+        obj = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid OPENSEEKER_REQUEST_EXTRA_BODY_JSON: {exc}") from exc
+    if not isinstance(obj, dict):
+        raise ValueError("OPENSEEKER_REQUEST_EXTRA_BODY_JSON must be a JSON object")
+    return obj
+
+
+def _call_chat_completion(
+    client: OpenAI,
+    *,
+    model_name: str,
+    messages: List[Dict[str, Any]],
+    tools: List[Dict[str, Any]],
+    max_tokens: int,
+    print_stream: bool,
+) -> Dict[str, Any]:
+    kwargs: Dict[str, Any] = {
+        "model": model_name,
+        "messages": messages,
+        "max_tokens": max_tokens,
+    }
+    if tools:
+        kwargs["tools"] = tools
+        kwargs["tool_choice"] = "auto"
+    extra_body = _extra_body_from_env()
+    if extra_body:
+        kwargs["extra_body"] = extra_body
+    response = client.chat.completions.create(**kwargs)
+    message = _message_to_dict(response.choices[0].message)
+    if print_stream and message.get("content"):
+        print(message["content"], end="", flush=True)
+    return message
+
+
+def _messages_to_text(messages: List[Dict[str, Any]]) -> str:
+    chunks: List[str] = []
+    for msg in messages:
+        role = msg.get("role", "")
+        chunks.append(f"<|im_start|>{role}\n")
+        content = msg.get("content")
+        if content:
+            chunks.append(str(content))
+        for tc in msg.get("tool_calls") or []:
+            chunks.append("\n<tool_call>\n")
+            chunks.append(json.dumps(tc, ensure_ascii=False))
+            chunks.append("\n</tool_call>")
+        chunks.append("<|im_end|>\n")
+    return "".join(chunks)
+
+
+def call_llm_with_tool(item: Dict[str, Any], args, *, return_metrics: bool = False, return_trace: bool = False):
+    query = item["query"]
+    client, model_name = _build_client()
+    messages: List[Dict[str, Any]] = [
+        {"role": "system", "content": developer_prompt},
+        {"role": "user", "content": query},
+    ]
+
+    trace: List[Dict[str, Any]] = []
+    step_num = 0
+    tool_count = 0
+    tool_count_max = int(getattr(args, "tool_count_max", 200))
+    max_tokens = int(getattr(args, "max_tokens", 16384))
+    print_stream = bool(getattr(args, "print_stream", False))
+    filter_huggingface = bool(getattr(args, "filter_huggingface", False))
+    finish_reason = "unknown"
+    error_info: Optional[Dict[str, Any]] = None
+
+    while True:
+        tools_for_call = tools_all if tool_count < tool_count_max else []
+        message = _call_chat_completion(
+            client,
+            model_name=model_name,
+            messages=messages,
+            tools=tools_for_call,
+            max_tokens=max_tokens,
+            print_stream=print_stream,
+        )
+        step_num += 1
+        tool_calls = _extract_tool_calls(message)
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        messages.append(message)
+
+        if return_trace:
+            trace.append(
+                {
+                    "step": step_num,
+                    "type": "model_message",
+                    "content": {
+                        "reasoning_content": message.get("reasoning_content") or message.get("reasoning") or "",
+                        "content": message.get("content") or "",
+                        "tool_calls": [
+                            {"function": tc.get("function", {})} for tc in tool_calls
+                        ],
+                    },
+                }
+            )
+
+        if not tool_calls:
+            finish_reason = "answer"
+            break
+
+        for tc in tool_calls:
+            fn = tc.get("function") or {}
+            tool_name = (fn.get("name") or "").strip()
+            tool_args = _parse_tool_arguments(fn.get("arguments"))
+            try:
+                tool_output = _execute_tool(
+                    tool_name,
+                    tool_args,
+                    filter_huggingface=filter_huggingface,
+                )
+            except Exception as exc:
+                tool_output = f"Error during tool execution: {type(exc).__name__}: {exc}"
+
+            try:
+                _print_tool_call(tool_name or "unknown", tool_args, tool_output)
+            except Exception:
+                pass
+
+            tool_count += 1
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.get("id") or str(uuid.uuid4()),
+                    "name": tool_name,
+                    "content": tool_output,
+                }
+            )
+            if return_trace:
+                trace.append(
+                    {
+                        "step": step_num,
+                        "type": "tool_call",
+                        "content": {"tool_name": tool_name, "tool_args": tool_args},
+                    }
+                )
+                trace.append(
+                    {
+                        "step": step_num,
+                        "type": "tool_response",
+                        "content": {"tool_name": tool_name, "tool_response": tool_output},
+                    }
+                )
+            if tool_count >= tool_count_max:
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "You have reached the tool usage limit. Do not call any more tools. "
+                            "Provide the final answer now."
+                        ),
+                    }
+                )
+                break
+
+        if tool_count >= tool_count_max:
+            continue
+
+    full_traj = _messages_to_text(messages)
+    metrics: Dict[str, Any] = {
+        "tool_calls": tool_count,
+        "context_chars": len(full_traj),
+        "finish_reason": finish_reason,
+    }
+    if error_info is not None:
+        metrics["error"] = error_info
+    if return_metrics:
+        if return_trace:
+            return full_traj, metrics, trace
+        return full_traj, metrics
+    if return_trace:
+        return full_traj, trace
+    return full_traj
+
+
+def _get_last_assistant_answer_from_messages(full_traj: str) -> str:
+    if not full_traj:
+        return ""
+    parts = full_traj.split("<|im_start|>assistant")
+    if len(parts) < 2:
+        return full_traj.strip()
+    last = parts[-1]
+    if "<|im_end|>" in last:
+        last = last.split("<|im_end|>", 1)[0]
+    return last.strip()
+
+
+def _estimate_tokens_from_chars(n_chars: int) -> int:
+    return max(1, int(n_chars / 4))
+
+
+def solve_query_with_tools(
+    query: str,
+    *,
+    max_tokens: int = 16384,
+    tool_count_max: int = 200,
+    print_stream: bool = False,
+    filter_huggingface: bool = False,
+    return_full_traj: bool = True,
+    return_trace: bool = True,
+) -> Dict[str, Any]:
+    start = time.time()
+    args = argparse.Namespace(
+        max_tokens=int(max_tokens),
+        tool_count_max=int(tool_count_max),
+        print_stream=bool(print_stream),
+        filter_huggingface=bool(filter_huggingface),
+    )
+
+    item = {"query": query}
+    call_result = call_llm_with_tool(item, args, return_metrics=True, return_trace=return_trace)
+    if return_trace:
+        full_traj, metrics, trace = call_result
+    else:
+        full_traj, metrics = call_result
+        trace = []
+
+    elapsed = time.time() - start
+    answer = _get_last_assistant_answer_from_messages(full_traj)
+    context_chars = int(metrics.get("context_chars", len(full_traj)))
+    tool_calls = int(metrics.get("tool_calls", 0))
+
+    result: Dict[str, Any] = {
+        "answer": answer,
+        "tool_calls": tool_calls,
+        "elapsed_seconds": elapsed,
+        "context_chars": context_chars,
+        "context_est_tokens": _estimate_tokens_from_chars(context_chars),
+        "finish_reason": metrics.get("finish_reason", "unknown"),
+    }
+    if metrics.get("error") is not None:
+        result["error"] = metrics.get("error")
+        result["answer"] = ""
+    if return_full_traj:
+        result["full_traj"] = full_traj
+    if return_trace:
+        result["trace"] = trace
+    return result
+
+
+if __name__ == "__main__":
+    q = os.environ.get("OPENSEEKER_QUERY", "what's openai's leader")
+    res = solve_query_with_tools(q, print_stream=True, tool_count_max=200)
+    result_dir = os.path.join(_THIS_DIR, "../..", "result/test")
+    os.makedirs(result_dir, exist_ok=True)
+    result_path = os.path.join(result_dir, "res3.json")
+    with open(result_path, "w", encoding="utf-8") as f:
+        json.dump(res, f, ensure_ascii=False)
+    print("\n\n=== ANSWER ===\n")
+    print(res["answer"])

--- a/src/tools/code_exec.py
+++ b/src/tools/code_exec.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import atexit
+import html
+import importlib.util
+import os
+import re
+import sys
+import threading
+from typing import Any
+
+DEFAULT_SANDBOX_TIMEOUT = 600
+DEFAULT_E2B_TEMPLATE_ID = "1av7fdjfvcparqo8efq6"
+MAX_RESULT_LEN = 20_000
+MAX_ERROR_LEN = 4_000
+
+E2B_IMPORT_NAME = "e2b_code_interpreter"
+E2B_PACKAGE_NAME = "e2b-code-interpreter"
+E2B_MISSING_MESSAGE = (
+    f"Error: {E2B_PACKAGE_NAME} package is not installed in the OpenSeeker runtime. "
+    f"Install it with: pip install {E2B_PACKAGE_NAME}"
+)
+
+DEFAULT_CODE_EXEC_DESCRIPTION = (
+    "Execute a shell command in the shared execution environment for this task attempt.\n\n"
+    "All calls in the same attempt reuse one sandbox, so files, installed packages, "
+    "and working-directory state persist across calls. Do not create or pass sandbox ids. "
+    "Use Python by running python commands or scripts, for example `python - <<'PY' ... PY`. "
+    "Use this for calculations, symbolic math (sympy), numeric work (numpy/scipy), data "
+    "processing, installing lightweight packages, writing/reading files, and verifying "
+    "intermediate results.\n\n"
+    "Args:\n"
+    "    cmd: The shell command to execute in the shared sandbox.\n\n"
+    "Returns:\n"
+    "    XML containing exit_code, stdout, and stderr."
+)
+
+CODE_EXEC_TOOL_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "code_exec",
+        "description": DEFAULT_CODE_EXEC_DESCRIPTION,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "cmd": {
+                    "type": "string",
+                    "description": "Shell command to execute in the shared sandbox.",
+                },
+            },
+            "required": ["cmd"],
+        },
+    },
+}
+
+_STATUS_PREFIX_RE = re.compile(r"^\s*(\d{3})\b")
+_LOCK = threading.Lock()
+_SANDBOX: Any | None = None
+_SANDBOX_ID: str | None = None
+
+
+def is_e2b_available() -> bool:
+    if E2B_IMPORT_NAME in sys.modules:
+        return True
+    return importlib.util.find_spec(E2B_IMPORT_NAME) is not None
+
+
+def validate_code_exec_environment() -> list[str]:
+    problems: list[str] = []
+    if not os.environ.get("E2B_API_KEY"):
+        problems.append("E2B_API_KEY is not set")
+    if not is_e2b_available():
+        problems.append(f"{E2B_PACKAGE_NAME} is not installed")
+    return problems
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) > limit:
+        return text[:limit] + " [truncated due to length limit]"
+    return text
+
+
+def _format_shell_result(result: Any) -> str:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code is None:
+        exit_code = 0
+    stdout = getattr(result, "stdout", "")
+    stderr = getattr(result, "stderr", "")
+    return (
+        "<shell_results>\n"
+        f"<exit_code>{html.escape(str(exit_code))}</exit_code>\n"
+        f"<stdout>{html.escape(_truncate(str(stdout or ''), MAX_RESULT_LEN))}</stdout>\n"
+        f"<stderr>{html.escape(_truncate(str(stderr or ''), MAX_ERROR_LEN))}</stderr>\n"
+        "</shell_results>"
+    )
+
+
+def _load_sandbox_class() -> Any:
+    try:
+        from e2b_code_interpreter import Sandbox  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise RuntimeError(E2B_MISSING_MESSAGE) from exc
+    return Sandbox
+
+
+def _get_sandbox_id(sandbox: Any) -> str | None:
+    sandbox_id = getattr(sandbox, "sandbox_id", None)
+    if sandbox_id:
+        return str(sandbox_id)
+    try:
+        info = sandbox.get_info()
+    except Exception:
+        return None
+    sandbox_id = getattr(info, "sandbox_id", None) or getattr(info, "id", None)
+    return str(sandbox_id) if sandbox_id else None
+
+
+def _new_sandbox() -> Any:
+    api_key = os.environ.get("E2B_API_KEY")
+    if not api_key:
+        raise RuntimeError("E2B_API_KEY is not set")
+    Sandbox = _load_sandbox_class()
+    create = getattr(Sandbox, "create", None)
+    kwargs: dict[str, Any] = {"timeout": DEFAULT_SANDBOX_TIMEOUT, "api_key": api_key}
+    if DEFAULT_E2B_TEMPLATE_ID:
+        kwargs["template"] = DEFAULT_E2B_TEMPLATE_ID
+    if callable(create):
+        try:
+            return create(**kwargs)
+        except TypeError as exc:
+            if "template" not in str(exc):
+                raise
+            kwargs.pop("template", None)
+            return create(**kwargs)
+    return Sandbox(**kwargs)
+
+
+def _is_sandbox_not_found(exc: BaseException) -> bool:
+    lowered = str(exc).lower()
+    return "sandbox was not found" in lowered or "sandbox not found" in lowered
+
+
+def _error_status(exc: BaseException) -> int | None:
+    try:
+        from e2b.exceptions import RateLimitException  # type: ignore[import-untyped]
+
+        if isinstance(exc, RateLimitException):
+            return 429
+    except Exception:
+        pass
+    match = _STATUS_PREFIX_RE.match(str(exc))
+    return int(match.group(1)) if match else None
+
+
+def _get_or_create_sandbox() -> Any:
+    global _SANDBOX, _SANDBOX_ID
+    with _LOCK:
+        if _SANDBOX is None:
+            _SANDBOX = _new_sandbox()
+            _SANDBOX_ID = _get_sandbox_id(_SANDBOX)
+        try:
+            _SANDBOX.set_timeout(DEFAULT_SANDBOX_TIMEOUT)
+        except Exception:
+            pass
+        return _SANDBOX
+
+
+def reset_code_exec_sandbox() -> None:
+    global _SANDBOX, _SANDBOX_ID
+    with _LOCK:
+        sandbox = _SANDBOX
+        _SANDBOX = None
+        _SANDBOX_ID = None
+    if sandbox is not None:
+        try:
+            sandbox.kill()
+        except Exception:
+            pass
+
+
+atexit.register(reset_code_exec_sandbox)
+
+
+def code_exec(cmd: str) -> str:
+    if not isinstance(cmd, str) or not cmd.strip():
+        return "[ERROR]: cmd must be a non-empty string."
+
+    last_error: BaseException | None = None
+    for attempt in range(1, 4):
+        try:
+            sandbox = _get_or_create_sandbox()
+            result = sandbox.commands.run(cmd)
+            return _format_shell_result(result)
+        except Exception as exc:
+            last_error = exc
+            status = _error_status(exc)
+            if _is_sandbox_not_found(exc):
+                reset_code_exec_sandbox()
+                continue
+            if status in {408, 429} or (status is not None and status >= 500):
+                continue
+            break
+
+    detail = _truncate(str(last_error or "unknown error"), MAX_ERROR_LEN)
+    return (
+        "<shell_results>\n"
+        "<exit_code>1</exit_code>\n"
+        "<stdout></stdout>\n"
+        f"<stderr>{html.escape(detail)}</stderr>\n"
+        "</shell_results>"
+    )


### PR DESCRIPTION
## Summary
- add src/tools/code_exec.py as the single Axis-style code execution tool
- add src/llm_tool_openseeker_v3.py using OpenAI chat completions messages/tools instead of manual chat-template rendering
- add eval/generate_answer_v3.py wired to the v3 tool runner

## Checks
- git diff --cached --check
- python3 -m py_compile src/tools/code_exec.py src/llm_tool_openseeker_v3.py eval/generate_answer_v3.py

Note: full import smoke test in the current shell is blocked because qwen-agent is not installed, although it is listed in requirements.txt.